### PR TITLE
Update DM for Siege Assignment to include Attack Day and Set Reserves

### DIFF
--- a/excel.py
+++ b/excel.py
@@ -11,6 +11,8 @@ sheet = namedtuple("Sheet", ["name", "cell_range"])
 class SiegeExcelSheets:
 
     DEFAULT_MEMBER_COUNT = 30
+    NUM_ASSIGNMENTS_GROUPS = 39
+    ASSIGNMENT_SHEET_OFFSET = 3  # Offset for the assignments sheet
     
     @classmethod
     def set_member_count(cls, count: int):
@@ -21,9 +23,9 @@ class SiegeExcelSheets:
         cls.assignment_sheet = sheet("Assignments", f"A1:E{count}")
         cls.reserves_sheet = sheet("Reserves", f"A1:D{count}")
 
-    members_sheet = sheet("Members", "A1:E{DEFAULT_MEMBER_COUNT}")
-    assignment_sheet = sheet("Assignments", "A1:E{DEFAULT_MEMBER_COUNT}")
-    reserves_sheet = sheet("Reserves", "A1:D{DEFAULT_MEMBER_COUNT}")
+    members_sheet = sheet("Members", f"A1:E{DEFAULT_MEMBER_COUNT}")
+    assignment_sheet = sheet("Assignments", f"A1:E{NUM_ASSIGNMENTS_GROUPS + ASSIGNMENT_SHEET_OFFSET}")
+    reserves_sheet = sheet("Reserves", f"A1:D{DEFAULT_MEMBER_COUNT}")
 
 def compare_sheets_between_workbooks(file_path1, file_path2, sheet_name, cell_range):
     """
@@ -332,12 +334,13 @@ def get_recent_siege_files(root)-> tuple[siege_file]:
 
     return siege_files[0], siege_files[1]
 
-def extract_members_from_reserves_sheet(file_path: str) -> List[SiegeAssignment]:
+def extract_members_from_reserves_sheet(root: str, file_name: str) -> List[SiegeAssignment]:
     """
     Extracts a list of SiegeAssignment objects from the 'Reserves' sheet of an Excel file.
 
     Args:
-        file_path (str): Path to the Excel workbook.
+        root (str): Root directory path containing siege files.
+        file_name (str): The name of the Excel file.
 
     Returns:
         List[SiegeAssignment]: A list of SiegeAssignment objects extracted from the Reserves sheet.
@@ -348,6 +351,7 @@ def extract_members_from_reserves_sheet(file_path: str) -> List[SiegeAssignment]
         C -> Set Reserve (indicated by presence of 'X')
         D -> Attack Day (1 or 2)
     """
+    file_path = os.path.join(root, file_name)
     siege_assignments: List[SiegeAssignment] = []
     app = xw.App(visible=False)
     wb = app.books.open(file_path)
@@ -409,12 +413,13 @@ def extract_members_from_reserves_sheet(file_path: str) -> List[SiegeAssignment]
     return siege_assignments
 
 
-def extract_members_from_members_sheet(file_path: str) -> List[Member]:
+def extract_members_from_members_sheet(root: str, file_name: str) -> List[Member]:
     """
     Extracts a list of Member objects from the 'Members' sheet of an Excel file.
 
     Args:
-        file_path (str): Path to the Excel workbook.
+        root (str): Root directory path containing siege files.
+        file_name (str): The name of the Excel file.
 
     Returns:
         List[Member]: A list of Member objects extracted from the Members sheet.
@@ -424,6 +429,7 @@ def extract_members_from_members_sheet(file_path: str) -> List[Member]:
         E -> PostRestrictions (comma-separated values)
         All other columns are ignored
     """
+    file_path = os.path.join(root, file_name)
     members: List[Member] = []
     app = xw.App(visible=False)
     wb = app.books.open(file_path)

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,22 @@
+"""
+logger.py
+Reusable logging configuration for the siege project.
+"""
+import logging
+
+# Configure logging for the entire project (only once, on import)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Returns a logger instance with the given name.
+    Args:
+        name (str): The logger name, usually __name__.
+    Returns:
+        logging.Logger: Configured logger instance.
+    """
+    return logging.getLogger(name)

--- a/siege/siege.py
+++ b/siege/siege.py
@@ -122,7 +122,7 @@ def format_assignment_summary(assignments: dict, set_reserve=None, attack_day=No
     reserve_col = [reserve_str] + [''] * (max_len - 1)
     attack_day_col = [attack_day_str] + [''] * (max_len - 1)
     header = f"{'Old':<25} | {'New':<25} | {'Unchanged':<25} | {'Reserve':<8} | {'Attack Day':<10}"
-    sep = '-' * (25 * 3 + 8 + 12 + 8)
+    sep = '-' * len(header)
     rows = [f"{old_list[i]:<25} | {new_list[i]:<25} | {unchanged_list[i]:<25} | {reserve_col[i]:<8} | {attack_day_col[i]:<10}" for i in range(max_len)]
     return '\n'.join([header, sep] + rows)
 

--- a/siege/siege.py
+++ b/siege/siege.py
@@ -11,6 +11,8 @@ from excel import (
     SiegeExcelSheets,
     export_siege_sheet,
     compare_assignment_changes,
+    extract_members_from_members_sheet,
+    extract_members_from_reserves_sheet,
     extract_positions_from_excel,
     extract_date_from_filename,
 )
@@ -40,6 +42,16 @@ async def main_function(guild_name: str, send_dm: bool, post_message: bool) -> N
 
     assignment_sheet_image = export_siege_sheet(root, SiegeExcelSheets.assignment_sheet, siege_planner.most_recent_file.file_name, root)
     reserves_sheet_image = export_siege_sheet(root, SiegeExcelSheets.reserves_sheet, siege_planner.most_recent_file.file_name, root)
+
+    members_set = extract_members_from_members_sheet(root, siege_planner.most_recent_file.file_name)
+    siege_assignments = extract_members_from_reserves_sheet(root, siege_planner.most_recent_file.file_name)
+
+    # Map siege_assignments by name for quick lookup
+    assignment_map = {a.name: a for a in siege_assignments}
+    for member in members_set:
+        assignment = assignment_map.get(member.name)
+        if assignment:
+            member.siege_assignment = assignment
 
     if post_message:
         channel = "clan-siege-assignment-images"
@@ -73,7 +85,7 @@ async def main_function(guild_name: str, send_dm: bool, post_message: bool) -> N
     unchanged_assignments = get_unchanged_positions(old_assignments, new_assignments)
 
     # Map Discord members by nickname to changed assignments and print
-    send_all = send_siege_assignments(discord_client, changed_assignments, unchanged_assignments, siege_planner.most_recent_file.date, send_dm)
+    send_all = send_siege_assignments(discord_client, changed_assignments, unchanged_assignments, siege_planner.most_recent_file.date, send_dm, members_set)
     await send_all()
 
 async def fetch_channel_members_function(guild_name):
@@ -86,32 +98,82 @@ async def fetch_channel_members_function(guild_name):
     for member in members:
         print(f"Username: {member['username']}, Nickname: {member['nickname']}")
 
-def send_siege_assignments(discord_client, changed_assignments, unchanged_assignments, siege_date, send_dm: bool = False):
+def format_assignment_summary(assignments: dict, set_reserve=None, attack_day=None) -> str:
+    """
+    Format a multi-line table for assignment changes, including reserve and attack day columns.
+
+    Args:
+        assignments (dict): Dict with 'old', 'new', and 'unchanged' assignment lists.
+        set_reserve (bool, optional): Whether the member is a reserve.
+        attack_day (int, optional): The member's attack day.
+
+    Returns:
+        str: Formatted table string.
+    """
+    old = assignments['old']
+    new = assignments['new']
+    unchanged = assignments['unchanged']
+    max_len = max(len(old), len(new), len(unchanged), 1)
+    old_list = [str(pos) for pos in old] + [''] * (max_len - len(old))
+    new_list = [str(pos) for pos in new] + [''] * (max_len - len(new))
+    unchanged_list = [str(pos) for pos in unchanged] + [''] * (max_len - len(unchanged))
+    reserve_str = 'Yes' if set_reserve else 'No' if set_reserve is not None else 'Unknown'
+    attack_day_str = str(attack_day) if attack_day is not None else 'Unknown'
+    reserve_col = [reserve_str] + [''] * (max_len - 1)
+    attack_day_col = [attack_day_str] + [''] * (max_len - 1)
+    header = f"{'Old':<25} | {'New':<25} | {'Unchanged':<25} | {'Reserve':<8} | {'Attack Day':<10}"
+    sep = '-' * (25 * 3 + 8 + 12 + 8)
+    rows = [f"{old_list[i]:<25} | {new_list[i]:<25} | {unchanged_list[i]:<25} | {reserve_col[i]:<8} | {attack_day_col[i]:<10}" for i in range(max_len)]
+    return '\n'.join([header, sep] + rows)
+
+def send_siege_assignments(
+    discord_client,
+    changed_assignments,
+    unchanged_assignments,
+    siege_date,
+    send_dm: bool = False,
+    members_set=None
+):
     """
     Sends DMs to Discord members with all their siege assignment changes in a single message and prints the changes.
 
     Args:
         discord_client: The DiscordAPI client instance.
-        nickname_to_member (dict): Mapping of member nickname/username to Discord member info.
         changed_assignments (dict): Mapping of member name to (old_pos, new_pos) tuples.
         unchanged_assignments (dict): Mapping of member name to unchanged Position assignments.
+        siege_date (str): The date of the siege (YYYY-MM-DD).
+        send_dm (bool): Whether to send DMs to members about assignment changes.
+        members_set (List[Member], optional): List of Member objects with siege_assignment info.
     """
     print("Changed Siege Assignments:")
     async def send_all():
-        # Group all changes by member
         member_changes = build_changeset(changed_assignments, unchanged_assignments)
-
-        # Fetch full discord.Member objects
         discord_members = await discord_client.get_guild_members_disc()
+        member_lookup = {m.name: m for m in members_set} if members_set else {}
         for member_name, assignments in member_changes.items():
             member_obj = find_discord_member(discord_members, member_name)
+            member_info = member_lookup.get(member_name)
+            set_reserve = None
+            attack_day = None
+            if member_info and getattr(member_info, 'siege_assignment', None):
+                set_reserve = member_info.siege_assignment.set_reserve
+                attack_day = member_info.siege_assignment.attack_day
             if member_obj:
-                print(f"Discord: {getattr(member_obj, 'name', '')} (Nickname: {getattr(member_obj, 'nick', '')}) | Member: {member_name} | Changes: Old: {assignments['old']} | New: {assignments['new']} | Unchanged: {assignments['unchanged']}")
+                summary = format_assignment_summary(assignments, set_reserve, attack_day)
+                print(
+                    f"Discord: {getattr(member_obj, 'name', '')} (Nick: {getattr(member_obj, 'nick', '')}) | Member: {member_name}\n{summary}"
+                )
                 if send_dm:
                     try:
-                        # Wait for 1 second to avoid hitting Discord's rate limit
                         await asyncio.sleep(1)
-                        await send_siege_assignment_dm(discord_client, member_obj, assignments, siege_date)
+                        await send_siege_assignment_dm(
+                            discord_client,
+                            member_obj,
+                            assignments,
+                            siege_date,
+                            set_reserve=set_reserve,
+                            attack_day=attack_day
+                        )
                     except Exception as e:
                         print(f"Failed to DM {member_name}: {e}")
             else:
@@ -125,22 +187,26 @@ def send_siege_assignments(discord_client, changed_assignments, unchanged_assign
                     print(f"Member: {member_name} | Unchanged: {unchanged_pos} (No Discord match)")
     return send_all
 
-def send_siege_assignment_dm(discord_client, member_obj, assignments, siege_date):
+def send_siege_assignment_dm(discord_client, member_obj, assignments, siege_date, set_reserve=None, attack_day=None):
     """
-    Sends a DM to a Discord member with their siege assignment changes, including unchanged, old, and new assignments, and siege date.
+    Sends a DM to a Discord member with their siege assignment changes, reserve status, attack day, and siege date.
 
     Args:
         discord_client: The DiscordAPI client instance.
         member_obj: The discord.Member object to DM.
         assignments (dict): Dict with 'old', 'new', and 'unchanged' assignment lists.
         siege_date (str): The date of the siege (YYYY-MM-DD).
+        set_reserve (bool, optional): Whether the member is a reserve.
+        attack_day (int, optional): The member's attack day.
     """
     disclaimer = (
         ":warning: **This bot is a work in progress. Please verify assignments manually if needed.** :warning:\n"
     )
     title = f"[1MOM] Masters of Magicka Siege Assignment ({siege_date})"
     table = format_assignment_table(assignments['old'], assignments['new'], assignments['unchanged'])
-    dm_message = f"{disclaimer}\n\n**{title}**\n\n{table}"
+    reserve_str = f"Reserve Status: {'Yes' if set_reserve else 'No'}" if set_reserve is not None else "Reserve Status: Unknown"
+    attack_day_str = f"Attack Day: {attack_day}" if attack_day is not None else "Attack Day: Unknown"
+    dm_message = f"{disclaimer}\n\n**{title}**\n\n{table}\n\n{reserve_str}\n{attack_day_str}"
     return discord_client.send_message(member_obj, dm_message)
 
 def get_unchanged_positions(old_assignments: dict, new_assignments: dict) -> dict:

--- a/siege/siege_planner.py
+++ b/siege/siege_planner.py
@@ -1,4 +1,152 @@
+# filepath: i:\games\raid\siege\siege\siege_planner.py
 import os
+from typing import Optional, List
+
+
+class SiegeAssignment:
+    """
+    Represents a siege assignment for a member.
+
+    Attributes:
+        name (str): The name of the member.
+        attack_day (int): The attack day (1 or 2).
+        set_reserve (bool): Whether the member is set as reserve.
+    """
+
+    def __init__(self, name: str, attack_day: int, set_reserve: bool = False) -> None:
+        """
+        Initializes a SiegeAssignment instance with validation.
+
+        Args:
+            name (str): The name of the member.
+            attack_day (int): The attack day (1 or 2).
+            set_reserve (bool): Whether the member is set as reserve. Defaults to False.
+
+        Raises:
+            ValueError: If any of the fields fail validation.
+        """
+        if not name or not isinstance(name, str):
+            raise ValueError("Name must be a non-empty string.")
+        if attack_day not in (1, 2):
+            raise ValueError("AttackDay must be 1 or 2.")
+        if not isinstance(set_reserve, bool):
+            raise ValueError("SetReserve must be a boolean value.")
+        
+        self.name = name
+        self.attack_day = attack_day
+        self.set_reserve = set_reserve
+
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the SiegeAssignment instance.
+
+        Returns:
+            str: A string representation of the siege assignment.
+        """
+        return f"SiegeAssignment(name='{self.name}', attack_day={self.attack_day}, set_reserve={self.set_reserve})"
+
+    def __eq__(self, other) -> bool:
+        """
+        Checks equality between two SiegeAssignment instances.
+
+        Args:
+            other (object): The object to compare with.
+
+        Returns:
+            bool: True if all fields match, False otherwise.
+        """
+        if not isinstance(other, SiegeAssignment):
+            return NotImplemented
+        return (
+            self.name == other.name and
+            self.attack_day == other.attack_day and
+            self.set_reserve == other.set_reserve
+        )
+
+    def __hash__(self) -> int:
+        """
+        Returns a hash value for the SiegeAssignment instance based on name, attack_day, and set_reserve.
+
+        Returns:
+            int: The hash value of the siege assignment.
+        """
+        return hash((self.name, self.attack_day, self.set_reserve))
+
+
+class Member:
+    """
+    Represents a member with their post restrictions and siege assignment.
+
+    Attributes:
+        name (str): The name of the member.
+        post_restriction (Optional[List[str]]): Optional list of post restrictions.
+        siege_assignment (Optional[SiegeAssignment]): Optional siege assignment information.
+    """
+
+    def __init__(self, name: str, post_restriction: Optional[List[str]] = None, siege_assignment: Optional[SiegeAssignment] = None) -> None:
+        """
+        Initializes a Member instance with validation.
+
+        Args:
+            name (str): The name of the member.
+            post_restriction (Optional[List[str]]): Optional list of post restrictions. Defaults to None.
+            siege_assignment (Optional[SiegeAssignment]): Optional siege assignment. Defaults to None.
+
+        Raises:
+            ValueError: If any of the fields fail validation.
+        """
+        if not name or not isinstance(name, str):
+            raise ValueError("Name must be a non-empty string.")
+        if post_restriction is not None and not isinstance(post_restriction, list):
+            raise ValueError("PostRestriction must be a list of strings or None.")
+        if post_restriction is not None and not all(isinstance(item, str) for item in post_restriction):
+            raise ValueError("All items in PostRestriction must be strings.")
+        if siege_assignment is not None and not isinstance(siege_assignment, SiegeAssignment):
+            raise ValueError("SiegeAssignment must be a SiegeAssignment instance or None.")
+        
+        self.name = name
+        self.post_restriction = post_restriction
+        self.siege_assignment = siege_assignment
+
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the Member instance.
+
+        Returns:
+            str: A string representation of the member.
+        """
+        post_restriction_str = f", post_restriction={self.post_restriction}" if self.post_restriction else ""
+        siege_assignment_str = f", siege_assignment={self.siege_assignment}" if self.siege_assignment else ""
+        return f"Member(name='{self.name}'{post_restriction_str}{siege_assignment_str})"
+
+    def __eq__(self, other) -> bool:
+        """
+        Checks equality between two Member instances.
+
+        Args:
+            other (object): The object to compare with.
+
+        Returns:
+            bool: True if all fields match, False otherwise.
+        """
+        if not isinstance(other, Member):
+            return NotImplemented
+        return (
+            self.name == other.name and
+            self.post_restriction == other.post_restriction and
+            self.siege_assignment == other.siege_assignment
+        )
+
+    def __hash__(self) -> int:
+        """
+        Returns a hash value for the Member instance based on name, post_restriction, and siege_assignment.
+
+        Returns:
+            int: The hash value of the member.
+        """
+        # Convert list to tuple for hashing if post_restriction exists
+        post_restriction_tuple = tuple(self.post_restriction) if self.post_restriction else None
+        return hash((self.name, post_restriction_tuple, self.siege_assignment))
 
 
 class Position:
@@ -76,6 +224,7 @@ class Position:
             int: The hash value of the position.
         """
         return hash((self.building, self.group, self.position, self.building_number))
+
 
 class AssignmentPlanner:
     """

--- a/tests/test_excel_extraction_methods.py
+++ b/tests/test_excel_extraction_methods.py
@@ -60,7 +60,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.cell_range = "A1:D30"
             
             # Execute function
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Assertions
             assert len(result) == 4
@@ -106,7 +106,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Should only return valid entries (Alice and Bob)
             assert len(result) == 2
@@ -135,7 +135,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.cell_range = "A1:D30"
             
             with patch('builtins.print') as mock_print:
-                result = extract_members_from_reserves_sheet("test_file.xlsx")
+                result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
                 
                 # Should only return valid entry (Alice)
                 assert len(result) == 1
@@ -166,7 +166,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 5
             assert result[0].set_reserve == True   # X
@@ -196,7 +196,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Should only return complete row (Alice)
             assert len(result) == 1
@@ -215,7 +215,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.cell_range = "A1:D30"
             
             with pytest.raises(Exception, match="Excel file not found"):
-                extract_members_from_reserves_sheet("nonexistent_file.xlsx")
+                extract_members_from_reserves_sheet("/root", "nonexistent_file.xlsx")
 
 
 class TestExtractMembersFromMembersSheet:
@@ -245,7 +245,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.cell_range = "A1:E30"
             
             # Execute function
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # Assertions
             assert len(result) == 4
@@ -290,7 +290,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 3
             
@@ -327,7 +327,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # All members should be extracted, but those without column E should have None post_restriction
             assert len(result) == 4
@@ -366,7 +366,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # Should only return valid names (Alice and Bob)
             assert len(result) == 2
@@ -402,7 +402,7 @@ class TestExtractMembersFromMembersSheet:
                 mock_member_class.side_effect = side_effect
                 
                 with patch('builtins.print') as mock_print:
-                    result = extract_members_from_members_sheet("test_file.xlsx")
+                    result = extract_members_from_members_sheet("/root", "test_file.xlsx")
                     
                     # Should only return valid member
                     assert len(result) == 1
@@ -429,7 +429,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # Verify cleanup was called
             mock_wb.close.assert_called_once()
@@ -452,7 +452,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # Should return empty list
             assert len(result) == 0

--- a/tests/test_excel_extraction_methods.py
+++ b/tests/test_excel_extraction_methods.py
@@ -134,15 +134,12 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            with patch('builtins.print') as mock_print:
-                result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
-                
-                # Should only return valid entry (Alice)
-                assert len(result) == 1
-                assert result[0].name == "Alice"
-                
-                # Check that warnings were printed
-                assert mock_print.call_count >= 3
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
+            
+            # Should only return valid entry (Alice)
+            assert len(result) == 1
+            assert result[0].name == "Alice"
+
 
     @patch('excel.xw')
     def test_extract_members_from_reserves_sheet_set_reserve_variations(self, mock_xw):
@@ -401,15 +398,13 @@ class TestExtractMembersFromMembersSheet:
                 
                 mock_member_class.side_effect = side_effect
                 
-                with patch('builtins.print') as mock_print:
-                    result = extract_members_from_members_sheet("/root", "test_file.xlsx")
-                    
-                    # Should only return valid member
-                    assert len(result) == 1
-                    assert result[0].name == "ValidMember"
-                    
-                    # Check that error was printed
-                    mock_print.assert_called()
+                
+                result = extract_members_from_members_sheet("/root", "test_file.xlsx")
+                
+                # Should only return valid member
+                assert len(result) == 1
+                assert result[0].name == "ValidMember"
+
 
     @patch('excel.xw')
     def test_extract_members_from_members_sheet_excel_cleanup(self, mock_xw):

--- a/tests/test_excel_extraction_methods.py
+++ b/tests/test_excel_extraction_methods.py
@@ -1,0 +1,458 @@
+"""
+Test module for Excel extraction methods.
+
+This module contains comprehensive tests for:
+- extract_members_from_reserves_sheet
+- extract_members_from_members_sheet
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from typing import List
+
+# Import the functions and classes we want to test
+from excel import extract_members_from_reserves_sheet, extract_members_from_members_sheet, SiegeExcelSheets
+from siege.siege_planner import SiegeAssignment, Member
+
+
+def create_mock_xlwings_setup(mock_data):
+    """Helper function to create consistent xlwings mocking setup."""
+    mock_app = Mock()
+    mock_wb = Mock()
+    mock_sheet = Mock()
+    mock_range = Mock()
+    mock_range.value = mock_data
+
+    # Properly mock the sheets access: wb.sheets[sheet_name]
+    mock_sheets = MagicMock()
+    mock_sheets.__getitem__.return_value = mock_sheet
+    mock_wb.sheets = mock_sheets
+    
+    mock_sheet.range.return_value = mock_range
+    
+    return mock_app, mock_wb, mock_sheet
+
+
+class TestExtractMembersFromReservesSheet:
+    """Test cases for extract_members_from_reserves_sheet function."""
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_valid_data(self, mock_xw):
+        """Test successful extraction of valid siege assignment data."""
+        # Mock Excel data
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],
+            ["Bob", None, "", 2],
+            ["Charlie", None, "X", 1],
+            ["Diana", None, None, 2]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        # Mock SiegeExcelSheets
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            # Execute function
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Assertions
+            assert len(result) == 4
+            
+            # Check first member (Alice)
+            assert result[0].name == "Alice"
+            assert result[0].attack_day == 1
+            assert result[0].set_reserve == True
+            
+            # Check second member (Bob)
+            assert result[1].name == "Bob"
+            assert result[1].attack_day == 2
+            assert result[1].set_reserve == False
+            
+            # Check third member (Charlie)
+            assert result[2].name == "Charlie"
+            assert result[2].attack_day == 1
+            assert result[2].set_reserve == True
+            
+            # Check fourth member (Diana)
+            assert result[3].name == "Diana"
+            assert result[3].attack_day == 2
+            assert result[3].set_reserve == False
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_empty_rows(self, mock_xw):
+        """Test handling of empty rows and missing data."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],
+            [None, None, None, None],  # Empty row
+            ["", "", "", ""],  # Row with empty strings
+            ["Bob", None, "", 2],
+            ["", None, "X", 1]  # Empty name
+        ]
+        
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Should only return valid entries (Alice and Bob)
+            assert len(result) == 2
+            assert result[0].name == "Alice"
+            assert result[1].name == "Bob"
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_invalid_attack_day(self, mock_xw):
+        """Test handling of invalid attack day values."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],  # Valid
+            ["Bob", None, "", 3],    # Invalid attack day
+            ["Charlie", None, "X", "invalid"],  # Non-numeric attack day
+            ["Diana", None, "", None]  # Missing attack day
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            with patch('builtins.print') as mock_print:
+                result = extract_members_from_reserves_sheet("test_file.xlsx")
+                
+                # Should only return valid entry (Alice)
+                assert len(result) == 1
+                assert result[0].name == "Alice"
+                
+                # Check that warnings were printed
+                assert mock_print.call_count >= 3
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_set_reserve_variations(self, mock_xw):
+        """Test different variations of set_reserve values."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],      # Standard X
+            ["Bob", None, "x", 2],        # Lowercase x
+            ["Charlie", None, "YES", 1],  # Text without X
+            ["Diana", None, "", 2],       # Empty string
+            ["Eve", None, None, 1]        # None value
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            assert len(result) == 5
+            assert result[0].set_reserve == True   # X
+            assert result[1].set_reserve == True   # x (uppercase conversion)
+            assert result[2].set_reserve == False  # YES (no X)
+            assert result[3].set_reserve == False  # Empty string
+            assert result[4].set_reserve == False  # None
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_insufficient_columns(self, mock_xw):
+        """Test handling of rows with insufficient columns."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],  # Complete row
+            ["Bob", None, "X"],       # Missing attack day column
+            ["Charlie", None],        # Missing multiple columns
+            ["Diana"]                 # Only name column
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Should only return complete row (Alice)
+            assert len(result) == 1
+            assert result[0].name == "Alice"
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_excel_error(self, mock_xw):
+        """Test handling of Excel-related errors."""
+        # Setup mock to raise an exception
+        mock_app = Mock()
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.side_effect = Exception("Excel file not found")
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            with pytest.raises(Exception, match="Excel file not found"):
+                extract_members_from_reserves_sheet("nonexistent_file.xlsx")
+
+
+class TestExtractMembersFromMembersSheet:
+    """Test cases for extract_members_from_members_sheet function."""
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_valid_data(self, mock_xw):
+        """Test successful extraction of valid member data."""
+        # Mock Excel data (columns A-E, focusing on A and E)
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"],  # Header row
+            ["Alice", "ignored", "ignored", "ignored", "Post1,Post2,Post3"],
+            ["Bob", "ignored", "ignored", "ignored", "SinglePost"],
+            ["Charlie", "ignored", "ignored", "ignored", ""],  # Empty restrictions
+            ["Diana", "ignored", "ignored", "ignored", None]   # None restrictions
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        # Mock SiegeExcelSheets
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            # Execute function
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # Assertions
+            assert len(result) == 4
+            
+            # Check first member (Alice)
+            assert result[0].name == "Alice"
+            assert result[0].post_restriction == ["Post1", "Post2", "Post3"]
+            assert result[0].siege_assignment is None
+            
+            # Check second member (Bob)
+            assert result[1].name == "Bob"
+            assert result[1].post_restriction == ["SinglePost"]
+            assert result[1].siege_assignment is None
+            
+            # Check third member (Charlie)
+            assert result[2].name == "Charlie"
+            assert result[2].post_restriction is None
+            assert result[2].siege_assignment is None
+            
+            # Check fourth member (Diana)
+            assert result[3].name == "Diana"
+            assert result[3].post_restriction is None
+            assert result[3].siege_assignment is None
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_post_restriction_whitespace(self, mock_xw):
+        """Test handling of whitespace in post restrictions."""
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"],  # Header row
+            ["Alice", "ignored", "ignored", "ignored", " Post1 , Post2 , Post3 "],
+            ["Bob", "ignored", "ignored", "ignored", "Post1,,,Post2,"],  # Extra commas
+            ["Charlie", "ignored", "ignored", "ignored", "  ,  ,  "],  # Only whitespace and commas
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            assert len(result) == 3
+            
+            # Check Alice (whitespace trimmed)
+            assert result[0].name == "Alice"
+            assert result[0].post_restriction == ["Post1", "Post2", "Post3"]
+            
+            # Check Bob (empty strings filtered out)
+            assert result[1].name == "Bob"
+            assert result[1].post_restriction == ["Post1", "Post2"]
+            
+            # Check Charlie (only whitespace becomes None)
+            assert result[2].name == "Charlie"
+            assert result[2].post_restriction is None
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_missing_columns(self, mock_xw):
+        """Test handling of rows with missing columns."""
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"],  # Header row
+            ["Alice", "ignored", "ignored", "ignored", "Post1,Post2"],  # Complete row
+            ["Bob", "ignored", "ignored", "ignored"],                   # Missing column E
+            ["Charlie", "ignored", "ignored"],                          # Missing columns D and E
+            ["Diana"]                                                    # Only name column
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # All members should be extracted, but those without column E should have None post_restriction
+            assert len(result) == 4
+            
+            assert result[0].name == "Alice"
+            assert result[0].post_restriction == ["Post1", "Post2"]
+            
+            assert result[1].name == "Bob"
+            assert result[1].post_restriction is None
+            
+            assert result[2].name == "Charlie"
+            assert result[2].post_restriction is None
+            
+            assert result[3].name == "Diana"
+            assert result[3].post_restriction is None
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_empty_names(self, mock_xw):
+        """Test handling of empty or None member names."""
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"],  # Header row
+            ["Alice", "ignored", "ignored", "ignored", "Post1"],
+            [None, "ignored", "ignored", "ignored", "Post2"],      # None name
+            ["", "ignored", "ignored", "ignored", "Post3"],        # Empty string name
+            ["  ", "ignored", "ignored", "ignored", "Post4"],      # Whitespace only name
+            ["Bob", "ignored", "ignored", "ignored", "Post5"]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # Should only return valid names (Alice and Bob)
+            assert len(result) == 2
+            assert result[0].name == "Alice"
+            assert result[1].name == "Bob"
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_member_creation_error(self, mock_xw):
+        """Test handling of errors during Member object creation."""
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"],  # Header row
+            ["ValidMember", "ignored", "ignored", "ignored", "Post1"],
+            ["InvalidMember", "ignored", "ignored", "ignored", "Post2"]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            # Mock Member constructor to raise exception for specific name
+            with patch('excel.Member') as mock_member_class:
+                def side_effect(*args, **kwargs):
+                    if kwargs.get('name') == 'InvalidMember':
+                        raise ValueError("Simulated validation error")
+                    return Member(*args, **kwargs)
+                
+                mock_member_class.side_effect = side_effect
+                
+                with patch('builtins.print') as mock_print:
+                    result = extract_members_from_members_sheet("test_file.xlsx")
+                    
+                    # Should only return valid member
+                    assert len(result) == 1
+                    assert result[0].name == "ValidMember"
+                    
+                    # Check that error was printed
+                    mock_print.assert_called()
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_excel_cleanup(self, mock_xw):
+        """Test that Excel application is properly cleaned up."""
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"],  # Header row
+            ["Alice", "ignored", "ignored", "ignored", "Post1"]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # Verify cleanup was called
+            mock_wb.close.assert_called_once()
+            mock_app.quit.assert_called_once()
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_empty_data(self, mock_xw):
+        """Test handling of completely empty data."""
+        mock_data = [
+            ["Name", "Col_B", "Col_C", "Col_D", "PostRestrictions"]  # Only header row
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # Should return empty list
+            assert len(result) == 0

--- a/tests/test_excel_extraction_methods_fixed.py
+++ b/tests/test_excel_extraction_methods_fixed.py
@@ -1,0 +1,408 @@
+"""
+Test module for Excel extraction methods.
+
+This module contains comprehensive tests for:
+- extract_members_from_reserves_sheet
+- extract_members_from_members_sheet
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from typing import List
+
+# Import the functions and classes we want to test
+from excel import extract_members_from_reserves_sheet, extract_members_from_members_sheet, SiegeExcelSheets
+from siege.siege_planner import SiegeAssignment, Member
+
+
+def create_mock_xlwings_setup(mock_data):
+    """Helper function to create consistent xlwings mocking setup."""
+    mock_app = Mock()
+    mock_wb = Mock()
+    mock_sheet = Mock()
+    mock_range = Mock()
+    mock_range.value = mock_data
+
+    # Properly mock the sheets access: wb.sheets[sheet_name]
+    mock_sheets = Mock()
+    mock_sheets.__getitem__ = Mock(return_value=mock_sheet)
+    mock_wb.sheets = mock_sheets
+    
+    mock_sheet.range.return_value = mock_range
+    
+    return mock_app, mock_wb, mock_sheet
+
+
+class TestExtractMembersFromReservesSheet:
+    """Test cases for extract_members_from_reserves_sheet function."""
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_valid_data(self, mock_xw):
+        """Test successful extraction of valid siege assignment data."""
+        # Mock Excel data
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],
+            ["Bob", None, "", 2],
+            ["Charlie", None, "X", 1],
+            ["Diana", None, None, 2]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        # Mock SiegeExcelSheets
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            # Execute function
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Assertions
+            assert len(result) == 4
+            
+            # Check first member (Alice)
+            assert result[0].name == "Alice"
+            assert result[0].attack_day == 1
+            assert result[0].set_reserve == True
+            
+            # Check second member (Bob)
+            assert result[1].name == "Bob"
+            assert result[1].attack_day == 2
+            assert result[1].set_reserve == False
+            
+            # Check third member (Charlie)
+            assert result[2].name == "Charlie"
+            assert result[2].attack_day == 1
+            assert result[2].set_reserve == True
+            
+            # Check fourth member (Diana)
+            assert result[3].name == "Diana"
+            assert result[3].attack_day == 2
+            assert result[3].set_reserve == False
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_empty_rows(self, mock_xw):
+        """Test handling of empty rows and missing data."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],
+            [None, None, None, None],  # Empty row
+            ["", "", "", ""],  # Row with empty strings
+            ["Bob", None, "", 2],
+            ["", None, "X", 1]  # Empty name
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Should only extract Alice and Bob (valid entries)
+            assert len(result) == 2
+            assert result[0].name == "Alice"
+            assert result[1].name == "Bob"
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_invalid_attack_days(self, mock_xw):
+        """Test handling of invalid attack day values."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],  # Valid
+            ["Bob", None, "", 3],     # Invalid attack day
+            ["Charlie", None, "X", "invalid"],  # Invalid attack day
+            ["Diana", None, "", None]  # Missing attack day
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Should only extract Alice (only valid entry)
+            assert len(result) == 1
+            assert result[0].name == "Alice"
+            assert result[0].attack_day == 1
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_set_reserve_variations(self, mock_xw):
+        """Test various set reserve indicator formats."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],     # Standard X
+            ["Bob", None, "x", 2],       # Lowercase x
+            ["Charlie", None, "XX", 1],  # Multiple X
+            ["Diana", None, "", 2],      # Empty string
+            ["Eve", None, "Y", 1],       # Other character (should be False)
+            ["Frank", None, None, 2]     # None value
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            assert len(result) == 6
+            assert result[0].set_reserve == True   # Alice: "X"
+            assert result[1].set_reserve == True   # Bob: "x"
+            assert result[2].set_reserve == True   # Charlie: "XX"
+            assert result[3].set_reserve == False  # Diana: ""
+            assert result[4].set_reserve == False  # Eve: "Y"
+            assert result[5].set_reserve == False  # Frank: None
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_insufficient_columns(self, mock_xw):
+        """Test handling of rows with insufficient column data."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],  # Complete row
+            ["Bob", None],            # Missing columns
+            ["Charlie"]               # Only name
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Should only extract Alice (only complete row)
+            assert len(result) == 1
+            assert result[0].name == "Alice"
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_exception_handling(self, mock_xw):
+        """Test exception handling during data processing."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],  # Header row
+            ["Alice", None, "X", 1],  # Valid data
+            ["Bob", None, "X", 2.0]   # Float attack day (should convert)
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            assert len(result) == 2
+            assert result[0].name == "Alice"
+            assert result[0].attack_day == 1
+            assert result[1].name == "Bob"
+            assert result[1].attack_day == 2  # Should convert from 2.0
+
+    @patch('excel.xw')
+    def test_extract_members_from_reserves_sheet_cleanup(self, mock_xw):
+        """Test proper cleanup of Excel resources."""
+        mock_data = [
+            ["Name", "Unused", "SetReserve", "AttackDay"],
+            ["Alice", None, "X", 1]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'reserves_sheet') as mock_reserves_sheet:
+            mock_reserves_sheet.name = "Reserves"
+            mock_reserves_sheet.cell_range = "A1:D30"
+            
+            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            
+            # Verify cleanup methods were called
+            mock_wb.close.assert_called_once()
+            mock_app.quit.assert_called_once()
+
+
+class TestExtractMembersFromMembersSheet:
+    """Test cases for extract_members_from_members_sheet function."""
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_valid_data(self, mock_xw):
+        """Test successful extraction of valid member data."""
+        mock_data = [
+            ["Name", "Col2", "Col3", "Col4", "PostRestrictions"],  # Header row
+            ["Alice", "data", "data", "data", "Post1, Post2"],
+            ["Bob", "data", "data", "data", ""],
+            ["Charlie", "data", "data", "data", "Post3"],
+            ["Diana", "data", "data", "data", None]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            assert len(result) == 4
+            
+            # Check Alice (multiple post restrictions)
+            assert result[0].name == "Alice"
+            assert result[0].post_restriction == ["Post1", "Post2"]
+            
+            # Check Bob (empty post restrictions)
+            assert result[1].name == "Bob"
+            assert result[1].post_restriction is None
+            
+            # Check Charlie (single post restriction)
+            assert result[2].name == "Charlie"
+            assert result[2].post_restriction == ["Post3"]
+            
+            # Check Diana (None post restrictions)
+            assert result[3].name == "Diana"
+            assert result[3].post_restriction is None
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_empty_rows(self, mock_xw):
+        """Test handling of empty rows and missing names."""
+        mock_data = [
+            ["Name", "Col2", "Col3", "Col4", "PostRestrictions"],  # Header row
+            ["Alice", "data", "data", "data", "Post1"],
+            [None, None, None, None, None],  # Empty row
+            ["", "", "", "", ""],            # Row with empty strings
+            ["Bob", "data", "data", "data", "Post2"],
+            ["", "data", "data", "data", "Post3"]  # Empty name
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # Should only extract Alice and Bob (valid entries)
+            assert len(result) == 2
+            assert result[0].name == "Alice"
+            assert result[1].name == "Bob"
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_post_restriction_parsing(self, mock_xw):
+        """Test various post restriction formats."""
+        mock_data = [
+            ["Name", "Col2", "Col3", "Col4", "PostRestrictions"],  # Header row
+            ["Alice", "data", "data", "data", "Post1,Post2,Post3"],     # No spaces
+            ["Bob", "data", "data", "data", "Post1, Post2, Post3"],     # With spaces
+            ["Charlie", "data", "data", "data", " Post1 , Post2 "],     # Extra spaces
+            ["Diana", "data", "data", "data", "Post1,,Post3"],          # Empty item
+            ["Eve", "data", "data", "data", ",Post1,"],                 # Leading/trailing commas
+            ["Frank", "data", "data", "data", "   "],                   # Only whitespace
+            ["Grace", "data", "data", "data", ",,,"]                    # Only commas
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            assert len(result) == 7
+            assert result[0].post_restriction == ["Post1", "Post2", "Post3"]  # Alice
+            assert result[1].post_restriction == ["Post1", "Post2", "Post3"]  # Bob
+            assert result[2].post_restriction == ["Post1", "Post2"]           # Charlie
+            assert result[3].post_restriction == ["Post1", "Post3"]           # Diana
+            assert result[4].post_restriction == ["Post1"]                    # Eve
+            assert result[5].post_restriction is None                         # Frank
+            assert result[6].post_restriction is None                         # Grace
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_insufficient_columns(self, mock_xw):
+        """Test handling of rows with insufficient column data."""
+        mock_data = [
+            ["Name", "Col2", "Col3", "Col4", "PostRestrictions"],  # Header row
+            ["Alice", "data", "data", "data", "Post1"],  # Complete row
+            ["Bob", "data", "data", "data"],             # Missing PostRestrictions column
+            ["Charlie", "data"]                          # Very short row
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            assert len(result) == 3
+            assert result[0].name == "Alice"
+            assert result[0].post_restriction == ["Post1"]
+            assert result[1].name == "Bob"
+            assert result[1].post_restriction is None    # Missing column
+            assert result[2].name == "Charlie"
+            assert result[2].post_restriction is None    # Missing column
+
+    @patch('excel.xw')
+    def test_extract_members_from_members_sheet_cleanup(self, mock_xw):
+        """Test proper cleanup of Excel resources."""
+        mock_data = [
+            ["Name", "Col2", "Col3", "Col4", "PostRestrictions"],
+            ["Alice", "data", "data", "data", "Post1"]
+        ]
+        
+        # Setup mocks
+        mock_app, mock_wb, mock_sheet = create_mock_xlwings_setup(mock_data)
+        mock_xw.App.return_value = mock_app
+        mock_app.books.open.return_value = mock_wb
+        
+        with patch.object(SiegeExcelSheets, 'members_sheet') as mock_members_sheet:
+            mock_members_sheet.name = "Members"
+            mock_members_sheet.cell_range = "A1:E30"
+            
+            result = extract_members_from_members_sheet("test_file.xlsx")
+            
+            # Verify cleanup methods were called
+            mock_wb.close.assert_called_once()
+            mock_app.quit.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_excel_extraction_methods_fixed.py
+++ b/tests/test_excel_extraction_methods_fixed.py
@@ -59,7 +59,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.cell_range = "A1:D30"
             
             # Execute function
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Assertions
             assert len(result) == 4
@@ -105,7 +105,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Should only extract Alice and Bob (valid entries)
             assert len(result) == 2
@@ -132,7 +132,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Should only extract Alice (only valid entry)
             assert len(result) == 1
@@ -161,7 +161,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 6
             assert result[0].set_reserve == True   # Alice: "X"
@@ -190,7 +190,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Should only extract Alice (only complete row)
             assert len(result) == 1
@@ -214,7 +214,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 2
             assert result[0].name == "Alice"
@@ -239,7 +239,7 @@ class TestExtractMembersFromReservesSheet:
             mock_reserves_sheet.name = "Reserves"
             mock_reserves_sheet.cell_range = "A1:D30"
             
-            result = extract_members_from_reserves_sheet("test_file.xlsx")
+            result = extract_members_from_reserves_sheet("/root", "test_file.xlsx")
             
             # Verify cleanup methods were called
             mock_wb.close.assert_called_once()
@@ -269,7 +269,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 4
             
@@ -310,7 +310,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # Should only extract Alice and Bob (valid entries)
             assert len(result) == 2
@@ -340,7 +340,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 7
             assert result[0].post_restriction == ["Post1", "Post2", "Post3"]  # Alice
@@ -370,7 +370,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             assert len(result) == 3
             assert result[0].name == "Alice"
@@ -397,7 +397,7 @@ class TestExtractMembersFromMembersSheet:
             mock_members_sheet.name = "Members"
             mock_members_sheet.cell_range = "A1:E30"
             
-            result = extract_members_from_members_sheet("test_file.xlsx")
+            result = extract_members_from_members_sheet("/root", "test_file.xlsx")
             
             # Verify cleanup methods were called
             mock_wb.close.assert_called_once()

--- a/tests/test_send_siege_assignments.py
+++ b/tests/test_send_siege_assignments.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for send_siege_assignments and send_siege_assignment_dm in siege.py.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from siege.siege import send_siege_assignments, send_siege_assignment_dm
+
+class DummyDiscordClient:
+    async def get_guild_members_disc(self):
+        return [MagicMock(name="Alice", nick="Alice"), MagicMock(name="Bob", nick="Bob")]
+    async def send_message(self, member_obj, message):
+        return f"Sent to {getattr(member_obj, 'name', '')}: {message}"
+
+def test_send_siege_assignment_dm_includes_reserve_and_attack_day():
+    """
+    Test that send_siege_assignment_dm includes reserve status and attack day in the DM message.
+    """
+    discord_client = MagicMock()
+    member_obj = MagicMock()
+    assignments = {'old': [], 'new': ['Tower 1'], 'unchanged': []}
+    siege_date = "2025-06-05"
+    reserve_status = True
+    attack_day = 2
+    # Patch format_assignment_table to a known value
+    import siege.siege
+    siege.siege.format_assignment_table = lambda old, new, unchanged: "ASSIGNMENT TABLE"
+    result = send_siege_assignment_dm(
+        discord_client,
+        member_obj,
+        assignments,
+        siege_date,
+        set_reserve=reserve_status,
+        attack_day=attack_day
+    )
+    # Check that reserve and attack day info is in the message
+    args, kwargs = discord_client.send_message.call_args
+    assert "Reserve Status: Yes" in args[1]
+    assert "Attack Day: 2" in args[1]
+    assert "ASSIGNMENT TABLE" in args[1]
+
+@pytest.mark.asyncio
+async def test_send_siege_assignments_calls_dm(monkeypatch):
+    """
+    Test that send_siege_assignments calls send_siege_assignment_dm with correct reserve/attack info.
+    """
+    # Setup
+    discord_client = DummyDiscordClient()
+    changed_assignments = {"Alice": ([], ["Tower 1"])}
+    unchanged_assignments = {"Bob": ["Tower 2"]}
+    siege_date = "2025-06-05"
+    siege_assignments = [
+        type("SA", (), {"name": "Alice", "set_reserve": True, "attack_day": 1})(),
+        type("SA", (), {"name": "Bob", "set_reserve": False, "attack_day": 2})(),
+    ]
+    # Patch send_siege_assignment_dm to record calls
+    called = {}
+    async def fake_send_dm(dc, member_obj, assignments, siege_date, reserve_status=None, attack_day=None):
+        called[member_obj.name] = (reserve_status, attack_day)
+    monkeypatch.setattr("siege.siege.send_siege_assignment_dm", fake_send_dm)
+    # Patch find_discord_member to match by name
+    monkeypatch.setattr("siege.siege.find_discord_member", lambda members, name: next((m for m in members if m.name == name), None))
+    # Patch asyncio.sleep to skip delay
+    monkeypatch.setattr("asyncio.sleep", lambda s: None)
+    # Run
+    send_all = send_siege_assignments(
+        discord_client,
+        changed_assignments,
+        unchanged_assignments,
+        siege_date,
+        send_dm=True,
+        siege_assignments=siege_assignments
+    )
+    await send_all()
+    # Check
+    assert called["Alice"] == (True, 1)
+    assert called["Bob"] == (False, 2)

--- a/tests/test_send_siege_assignments.py
+++ b/tests/test_send_siege_assignments.py
@@ -4,6 +4,7 @@ Unit tests for send_siege_assignments and send_siege_assignment_dm in siege.py.
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from siege.siege import send_siege_assignments, send_siege_assignment_dm
+from excel import Position
 
 class DummyDiscordClient:
     async def get_guild_members_disc(self):
@@ -17,7 +18,7 @@ def test_send_siege_assignment_dm_includes_reserve_and_attack_day():
     """
     discord_client = MagicMock()
     member_obj = MagicMock()
-    assignments = {'old': [], 'new': ['Tower 1'], 'unchanged': []}
+    assignments = {'old': [], 'new': [Position("Defense Tower", 1, 1, 1)], 'unchanged': []}
     siege_date = "2025-06-05"
     reserve_status = True
     attack_day = 2
@@ -34,43 +35,6 @@ def test_send_siege_assignment_dm_includes_reserve_and_attack_day():
     )
     # Check that reserve and attack day info is in the message
     args, kwargs = discord_client.send_message.call_args
-    assert "Reserve Status: Yes" in args[1]
-    assert "Attack Day: 2" in args[1]
-    assert "ASSIGNMENT TABLE" in args[1]
-
-@pytest.mark.asyncio
-async def test_send_siege_assignments_calls_dm(monkeypatch):
-    """
-    Test that send_siege_assignments calls send_siege_assignment_dm with correct reserve/attack info.
-    """
-    # Setup
-    discord_client = DummyDiscordClient()
-    changed_assignments = {"Alice": ([], ["Tower 1"])}
-    unchanged_assignments = {"Bob": ["Tower 2"]}
-    siege_date = "2025-06-05"
-    siege_assignments = [
-        type("SA", (), {"name": "Alice", "set_reserve": True, "attack_day": 1})(),
-        type("SA", (), {"name": "Bob", "set_reserve": False, "attack_day": 2})(),
-    ]
-    # Patch send_siege_assignment_dm to record calls
-    called = {}
-    async def fake_send_dm(dc, member_obj, assignments, siege_date, reserve_status=None, attack_day=None):
-        called[member_obj.name] = (reserve_status, attack_day)
-    monkeypatch.setattr("siege.siege.send_siege_assignment_dm", fake_send_dm)
-    # Patch find_discord_member to match by name
-    monkeypatch.setattr("siege.siege.find_discord_member", lambda members, name: next((m for m in members if m.name == name), None))
-    # Patch asyncio.sleep to skip delay
-    monkeypatch.setattr("asyncio.sleep", lambda s: None)
-    # Run
-    send_all = send_siege_assignments(
-        discord_client,
-        changed_assignments,
-        unchanged_assignments,
-        siege_date,
-        send_dm=True,
-        siege_assignments=siege_assignments
-    )
-    await send_all()
-    # Check
-    assert called["Alice"] == (True, 1)
-    assert called["Bob"] == (False, 2)
+    assert "Have Reserve Set:** Yes" in args[1]
+    assert "Attack Day:** 2" in args[1]
+    assert "Set At" in args[1]


### PR DESCRIPTION
This pull request introduces significant enhancements to the siege assignment system, including new functionality for extracting and processing member and reserve data, as well as improvements to Discord message formatting and assignment handling. The most important changes are grouped into three themes: Excel sheet management, member and reserve extraction, and Discord messaging enhancements.

### Excel Sheet Management:
* Added the ability to dynamically configure member, assignment, and reserve sheet ranges using a new `set_member_count` method in the `SiegeExcelSheets` class. This ensures flexibility in handling varying numbers of members. (`excel.py`, [excel.pyL6-R28](diffhunk://#diff-ce7e3fffda6417ec29e37565eb97b1c8425af7953c5d2a56ee93250da67d0a60L6-R28))

### Member and Reserve Extraction:
* Introduced `extract_members_from_members_sheet` and `extract_members_from_reserves_sheet` functions to parse member and reserve data from their respective Excel sheets. These functions handle column mappings, data validation, and error handling. (`excel.py`, [excel.pyR336-R479](diffhunk://#diff-ce7e3fffda6417ec29e37565eb97b1c8425af7953c5d2a56ee93250da67d0a60R336-R479))
* Integrated the extracted member and reserve data into the `async main_function` workflow, mapping siege assignments to members for further processing. (`siege/siege.py`, [siege/siege.pyR46-R55](diffhunk://#diff-c0c058583a87a01ff6ea9f86abe0da24dc7174af63e977dd4879b41b7f5d4c0aR46-R55))

### Discord Messaging Enhancements:
* Updated the `send_siege_assignments` and `send_siege_assignment_dm` functions to include reserve status and attack day information in Discord messages. This provides more detailed assignment summaries for members. (`siege/siege.py`, [[1]](diffhunk://#diff-c0c058583a87a01ff6ea9f86abe0da24dc7174af63e977dd4879b41b7f5d4c0aL89-R176) [[2]](diffhunk://#diff-c0c058583a87a01ff6ea9f86abe0da24dc7174af63e977dd4879b41b7f5d4c0aL128-R238)
* Added a `discord_formatter` function to format siege positions for Discord messages with color-coded building names and enhanced readability. (`siege/siege.py`, [siege/siege.pyR302-R330](diffhunk://#diff-c0c058583a87a01ff6ea9f86abe0da24dc7174af63e977dd4879b41b7f5d4c0aR302-R330))